### PR TITLE
Add verification step for ffmpeg binary

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -751,3 +751,5 @@ jobs:
 
           make -j$(nproc)
           make install
+      - name: Verify FFmpeg binary
+        run: build/${{ matrix.os }}-${{ matrix.arch }}/bin/ffmpeg -version


### PR DESCRIPTION
## Summary
- add a step to check built ffmpeg after `make install`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684018dc17a88326a1cf3a3d4e321229