### PR TITLE
Fix libopus update path

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -450,7 +450,7 @@ jobs:
       - name: Clone libopus source
         run: |
           cd $HOME/ffmpeg_sources
-          git -C opus pull 2> /dev/null || git clone --depth 1 https://github.com/xiph/opus.git libopus
+          git -C libopus pull 2> /dev/null || git clone --depth 1 https://github.com/xiph/opus.git libopus
       
       - name: Get libopus commit hash
         id: libopus_hash


### PR DESCRIPTION
## Summary
- fix command to pull libopus in build workflow

## Testing
- `yamllint -d '{extends: relaxed, rules: {line-length: disable}}' .github/workflows/build-ffmpeg.yml`

------
https://chatgpt.com/codex/tasks/task_e_684018d3ab748326a36081500cd6fb90