### PR TITLE
Fix libvpx install path in FFmpeg workflow

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -552,8 +552,8 @@ jobs:
 
           mkdir -p "$libvpx_BUILD_DIR"
 
-          cd $HOME/ffmpeg_sources/libvpx
-          PATH="$HOME/bin:$PATH" ./configure --prefix="$libvpx_BUILD_DIR" --disable-examples --disable-unit-tests --enable-vp9-highbitdepth --as=yasm
+          cd "$libvpx_SRC_DIR"
+          PATH="$HOME/bin:$PATH" ./configure --prefix="$libvpx_INSTALL_DIR" --disable-examples --disable-unit-tests --enable-vp9-highbitdepth --as=yasm
           make
           make install
 


### PR DESCRIPTION
## Summary
- ensure libvpx installs to the intended prefix

## Testing
- `yamllint .github/workflows/build-ffmpeg.yml`

------
https://chatgpt.com/codex/tasks/task_e_6840174ff9b48326a74242b884ee419e