### PR TITLE
Fix gnutls detection in workflow

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -708,7 +708,7 @@ jobs:
           cd ffmpeg-source
 
           # Dynamically gather all valid .pc dirs
-          export PKG_CONFIG_PATH=$(find ~/ffmpeg_build -type f -name '*.pc' -exec dirname {} \; | sort -u | tr '\n' ':' | sed 's/:$//')
+          export PKG_CONFIG_PATH="$(pkg-config --variable pc_path pkg-config):$(find ~/ffmpeg_build -type f -name '*.pc' -exec dirname {} \; | sort -u | tr '\n' ':' | sed 's/:$//')"
 
           # Set compiler flags
           export CFLAGS="-O3 -mtune=generic"


### PR DESCRIPTION
## Summary
- ensure the workflow's `PKG_CONFIG_PATH` also includes the system pkgconfig
  directories

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840232d9f148326ad86a218ddbdf23b