### PR TITLE
Fix YAML indentation

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -726,7 +726,7 @@ jobs:
           export PKG_CONFIG_PATH=$(find ~/ffmpeg_build -type f -name '*.pc' -exec dirname {} \; | sort -u | tr '\n' ':' | sed 's/:$//')
           export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(pkg-config --variable pc_path pkg-config)"
 
-# Set compiler flags
+          # Set compiler flags
           export CFLAGS="-O3 -mtune=generic"
           export CXXFLAGS="-O3 -mtune=generic"
 


### PR DESCRIPTION
## Summary
- fix indentation for comment inside FFmpeg build step in workflow

## Testing
- `python3 - <<'EOF'
import yaml
yaml.safe_load(open('.github/workflows/build-ffmpeg.yml'))
print('Valid')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68402f7caf188326a0a9eef4548eba0a